### PR TITLE
Add Jest setup and basic DOM test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "presentador",
+  "version": "1.0.0",
+  "description": "Este proyecto permite subir archivos PDF o DOCX, convertirlos a imágenes y navegar entre ellas como slides.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -139,4 +139,15 @@ function resetSlides() {
     slides = [];
     currentSlide = 0;
     slideViewer.innerHTML = '';
-} 
+}
+
+// Exports for testing in Node.js
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        resetSlides,
+        getSlides: () => slides,
+        setSlides: (arr) => { slides = arr; },
+        getCurrentSlide: () => currentSlide,
+        setCurrentSlide: (val) => { currentSlide = val; },
+    };
+}

--- a/script.test.js
+++ b/script.test.js
@@ -1,0 +1,23 @@
+const presenter = require('./script');
+
+document.body.innerHTML = `
+  <input id="fileInput" />
+  <div id="slideViewer">initial</div>
+  <button id="btnAnterior"></button>
+  <button id="btnSiguiente"></button>
+  <button id="btnInicio"></button>
+  <button id="btnIr"></button>
+  <button id="btnRedireccionar"></button>
+`;
+
+presenter.setSlides(['a', 'b']);
+presenter.setCurrentSlide(1);
+
+presenter.resetSlides();
+
+test('resetSlides clears state and viewer', () => {
+  expect(presenter.getSlides()).toEqual([]);
+  expect(presenter.getCurrentSlide()).toBe(0);
+  expect(document.getElementById('slideViewer').innerHTML).toBe('');
+});
+


### PR DESCRIPTION
## Summary
- set up `jest` as a dev dependency and configure jsdom
- export helpers from `script.js` for testability
- add a test verifying `resetSlides`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b83987db4832485458739f1c2f169